### PR TITLE
變更 API Key 讀入方式 - 改用 dotenv

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+# airtable API key
+AIRTABLE_KEY="keyC123ABcxxxxxxx"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .DS_Store
 node_modules/
-creds.js
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -250,6 +250,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "dotenv": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g=="
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.18.0",
+    "dotenv": "^7.0.0",
     "puppeteer": "^1.13.0"
   },
   "devDependencies": {

--- a/src/js/scrape-niceday.js
+++ b/src/js/scrape-niceday.js
@@ -1,6 +1,6 @@
 const puppeteer = require('puppeteer');
 const axios = require('axios');
-const CREDS = require('../../creds');
+require('dotenv').config()
 
 /**
  * 取得日期供網址參數用
@@ -128,7 +128,7 @@ async function crawlPageContent(page, url, pageNum) {
 async function saveDataToAirtable(data) {
   const airtable_api = 'https://api.airtable.com/v0/appQuTk2v5mu4Awgc/Table%201?api_key=';
 
-  axios.post(`${airtable_api}${CREDS.airtableKey}`, {
+  axios.post(`${airtable_api}${process.env.AIRTABLE_KEY}`, {
     fields: data,
   })
     .catch(error => console.error(error));

--- a/src/js/scrape-niceday.js
+++ b/src/js/scrape-niceday.js
@@ -128,7 +128,7 @@ async function crawlPageContent(page, url, pageNum) {
 async function saveDataToAirtable(data) {
   const airtable_api_url = 'https://api.airtable.com/v0/appQuTk2v5mu4Awgc/Table%201?api_key=';
 
-  axios.post(`${airtable_api_url}${CREDS.airtableKey}`, {
+  axios.post(`${airtable_api_url}${process.env.AIRTABLE_KEY}`, {
     fields: data,
   })
     .catch(error => console.error(error));


### PR DESCRIPTION
# What? Why?
變更原先的 api key 儲存方式

```js
const CREDS = require('../../creds');
```

👉 改用社會大眾使用的方式 - dotenv 套件
https://github.com/motdotla/dotenv

### 什麼是 dotenv
有許多參數、 api key 、密碼不應該進 git 

一般來說專案根目錄下會有兩個檔案, 不進入 git 的 `.env` 和 進入 git 的 `.env.sample`
![image](https://user-images.githubusercontent.com/4863629/55861164-61812e00-5ba8-11e9-8702-1bd696568712.png)
(圖1)


新人或新 git repository 的人可以從 `.env.sample` 知道有哪些參數需要設定和參數的目的
![image](https://user-images.githubusercontent.com/4863629/55861036-1f57ec80-5ba8-11e9-9d90-345c2f95323b.png)


# How was it tested / usage?

- 在專案根目錄下，新增 `.env` 如上(圖1)
- 讓 `.env` 內容同 `.env.sample`
  - 將其內 AIRTABLE_KEY= 替換為正確 key 值
- command line 移動至專案目錄下
  - 執行 npm install
- done!


## 測試
`node src/js/test.js`
```js
const dotenv = require('dotenv').config();
console.log(dotenv.parsed);
console.log(process.env.AIRTABLE_KEY);
```
輸出
![image](https://user-images.githubusercontent.com/4863629/55861536-27fcf280-5ba9-11e9-8fb5-010c911dc066.png)